### PR TITLE
Kotlin のバージョンアップに合わせて compile sdk を 35へ更新、その他ライブラリも更新

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.10" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.example.engineer_code_check_multi_module"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.engineer_code_check_multi_module"
@@ -25,7 +25,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -60,9 +60,8 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
-
     // Hilt
     implementation(libs.hilt.android)
-    ksp (libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation)
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.example.data"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24
@@ -22,7 +22,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -47,10 +47,10 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    ksp (libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     // Retrofit
     implementation(libs.retrofit)
-    /// okhttp3
+    // / okhttp3
     implementation(libs.okhttp3)
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.example.database"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.example.domain"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24
@@ -22,7 +22,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -51,5 +51,5 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    ksp (libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.example.network"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24
@@ -24,7 +24,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -54,7 +54,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    ksp (libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     // Retrofit
     implementation(libs.retrofit)

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.example.detail"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.example.search"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 24
@@ -23,7 +23,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -62,9 +62,9 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    ksp (libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation)
 
-    /// Retrofit
+    // / Retrofit
     implementation(libs.retrofit)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+kotlin.native.binary.gc=cms

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-agp = "8.7.1"
-kotlin = "2.0.10"
-coreKtx = "1.13.1"
+agp = "8.7.2"
+kotlin = "2.0.21"
+coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.6"
+lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
-composeBom = "2024.10.00"
+composeBom = "2024.10.01"
 appcompat = "1.7.0"
 material = "1.12.0"
 
 #kotlin-coroutine/flow
-kotlinxCoroutines = "1.7.1"
+kotlinxCoroutines = "1.8.1"
 
 #kotlinx-serialization
 kotlinxSerialization = "1.7.3"
@@ -22,7 +22,7 @@ kotlinSerializationConverter = "1.0.0"
 #Room
 room = "2.6.1"
 #Ksp
-ksp = "2.0.10-1.0.24"
+ksp = "2.0.21-1.0.27"
 #Dagger hilt
 dagger = "2.52"
 hilt = "1.2.0"
@@ -32,11 +32,11 @@ retrofit = "2.11.0"
 okhttp3 = "4.12.0"
 
 # collectasstate with lifecycle
-lifecycle_version = "2.8.6"
+lifecycle_version = "2.8.7"
 
 #foundation
-foundation = "1.7.4"
-material3Android = "1.3.0"
+foundation = "1.7.5"
+material3Android = "1.3.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
- [kotlin lang versionup](https://kotlinlang.org/docs/whatsnew2020.html)
- [実験的導入: GC の同時マーキング](https://kotlinlang.org/docs/whatsnew2020.html#concurrent-marking-in-garbage-collector)
- [ksp version change with kotlin version up](https://github.com/google/ksp/releases/tag/2.0.21-1.0.27)
- update compile sdk from 34 to 35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated Kotlin native binary garbage collection strategy.
  
- **Improvements**
	- Incremented `compileSdk` version from 34 to 35 across multiple modules, enhancing compatibility with newer Android features.
	- Updated various library versions to their latest releases, ensuring improved performance and security.

- **Bug Fixes**
	- Minor formatting adjustments in build configuration files for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->